### PR TITLE
feat: Add Game API with CRUD and search functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,144 @@
+# /Game API Documentation
+
+Based on code forked from Jamie Cornick https://github.com/jamie-keyin/s4_2024_hockey_reg_system_api
+
+I have tried to stay with the original code structure and naming variants. For instance, the search endpoint is /search_game where I might have named it game/search.
+
+A key difference in this implementation is that more specific exceptions have been added at the GameService level to improve error handling.
+
+A robust search function has been implemented at the /search endpoint. It supports flexible date matching (by year, month, or day) and allows for combining multiple search criteria. The GameSearchCriteria enum was added to make this dynamic search logic more secure and maintainable by preventing illegal or unexpected search parameters.
+
+## Get All Games
+   Retrieves a list of all games in the database.
+
+Endpoint: GET /game
+
+Response: 200 OK
+
+Example Request:
+
+`curl http://localhost:8080/game`
+
+## Get Game By ID
+   Retrieves a single game by its unique ID.
+
+Endpoint: GET /game/{id}
+
+Response:
+
+200 OK if the game is found.
+
+404 Not Found if no game with the given ID exists.
+
+Example Request (for game with ID 1):
+
+`curl http://localhost:8080/game/1`
+
+## Create a New Game
+   Adds a new game to the database. The homeTeam and awayTeam objects must contain the ID of existing teams.
+
+Endpoint: POST /game
+
+Request Body: A JSON object representing the game.
+
+Response: 200 OK with the created game object, including its new ID.
+
+Example Request:
+
+`curl -X POST http://localhost:8080/game \
+-H "Content-Type: application/json" \
+-d '{
+"homeTeam": {
+"id": 1
+},
+"awayTeam": {
+"id": 2
+},
+"location": "Paradise",
+"gameDate": "2025-06-14T19:00:00"
+}
+`
+
+## Update a Game
+   Updates the details of an existing game.
+
+Endpoint: PUT /game/{id}
+
+Request Body: A JSON object with the updated game data. The ID in the body must match the ID in the URL.
+
+Response:
+
+200 OK with the updated game object.
+
+404 Not Found if the game doesn't exist.
+
+Example Request (to update game with ID 1):
+
+`curl -X PUT http://localhost:8080/game/1 \
+-H "Content-Type: application/json" \
+-d '{
+"id": 1,
+"homeTeam": {
+"id": 1
+},
+"awayTeam": {
+"id": 2
+},
+"location": "Mount Pearl",
+"gameDate": "2025-06-15T20:00:00"
+}`
+
+
+##Delete a Game
+   Deletes a game from the database by its ID.
+
+Endpoint: DELETE /game/{id}
+
+Response: 200 OK
+
+Example Request (to delete game with ID 1):
+
+`curl -X DELETE http://localhost:8080/game/1`
+
+## Search for Games
+   Performs a dynamic search for games based on one or more criteria. All provided criteria are combined with an AND condition. If no parameters are provided, it returns all games.
+
+Endpoint: GET /search_game
+
+Query Parameters:
+
+location (String): The city or venue of the game.
+
+`date (String): The date of the game. Can be a full year (YYYY), year and month (YYYY-MM), a specific day (YYYY-MM-DD), or a full timestamp.`
+
+homeTeamId (Long): The ID of the home team.
+
+awayTeamId (Long): The ID of the away team.
+
+homeTeamName (String): The name of the home team.
+
+awayTeamName (String): The name of the away team.
+
+Response: 200 OK with a list of matching games.
+
+### Search Examples
+Find all games in a specific location:
+
+`curl "http://localhost:8080/search?location=St. John's"`
+
+Find all games played during a specific month (e.g., June 2025):
+
+`curl "http://localhost:8080/search?date=2025-06"`
+
+Find all games where a specific team was the home team:
+
+`curl "http://localhost:8080/search?homeTeamName= Growlers"`
+
+Find games by combining multiple criteria (location and home team ID):
+
+`curl "http://localhost:8080/search?location=Paradise&homeTeamId=1"`
+
+Find games on a specific day when a specific team was the away team:
+
+`curl "http://localhost:8080/search?date=2025-06-14&awayTeamName=Sports Team`
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Based on code forked from Jamie Cornick https://github.com/jamie-keyin/s4_2024_hockey_reg_system_api
 
-I have tried to stay with the original code structure and naming variants. For instance, the search endpoint is /search_game where I might have named it game/search.
+I have tried to stay with the original code structure and naming variants. For instance, the search endpoint is /game_search where I might have named it game/search.
 
 A key difference in this implementation is that more specific exceptions have been added at the GameService level to improve error handling.
 
@@ -103,13 +103,13 @@ Example Request (to delete game with ID 1):
 ## Search for Games
    Performs a dynamic search for games based on one or more criteria. All provided criteria are combined with an AND condition. If no parameters are provided, it returns all games.
 
-Endpoint: GET /search_game
+Endpoint: GET /game_search
 
 Query Parameters:
 
 location (String): The city or venue of the game.
 
-`date (String): The date of the game. Can be a full year (YYYY), year and month (YYYY-MM), a specific day (YYYY-MM-DD), or a full timestamp.`
+date (String): The date of the game. Can be a full year (YYYY), year and month (YYYY-MM), a specific day (YYYY-MM-DD), or a full timestamp.
 
 homeTeamId (Long): The ID of the home team.
 
@@ -124,21 +124,21 @@ Response: 200 OK with a list of matching games.
 ### Search Examples
 Find all games in a specific location:
 
-`curl "http://localhost:8080/search?location=St. John's"`
+`curl "http://localhost:8080/game_search?location=St. John's"`
 
 Find all games played during a specific month (e.g., June 2025):
 
-`curl "http://localhost:8080/search?date=2025-06"`
+`curl "http://localhost:8080/game_search?date=2025-06"`
 
 Find all games where a specific team was the home team:
 
-`curl "http://localhost:8080/search?homeTeamName= Growlers"`
+`curl "http://localhost:8080/game_search?homeTeamName= Growlers"`
 
 Find games by combining multiple criteria (location and home team ID):
 
-`curl "http://localhost:8080/search?location=Paradise&homeTeamId=1"`
+`curl "http://localhost:8080/game_search?location=Paradise&homeTeamId=1"`
 
 Find games on a specific day when a specific team was the away team:
 
-`curl "http://localhost:8080/search?date=2025-06-14&awayTeamName=Sports Team`
+`curl "http://localhost:8080/game_search?date=2025-06-14&awayTeamName=Sports Team`
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.keyin</groupId>
     <artifactId>s4_2024_hockey_reg_system_api</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.01-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>20</maven.compiler.source>

--- a/src/main/java/com/keyin/rest/game/Game.java
+++ b/src/main/java/com/keyin/rest/game/Game.java
@@ -1,0 +1,4 @@
+package com.keyin.rest.game;
+
+public class Game {
+}

--- a/src/main/java/com/keyin/rest/game/Game.java
+++ b/src/main/java/com/keyin/rest/game/Game.java
@@ -1,4 +1,66 @@
 package com.keyin.rest.game;
 
+import jakarta.persistence.*;
+import com.keyin.rest.team.Team;
+import java.time.LocalDateTime;
+
+//A Game must have a home Team and an Away team, a String for the location, and a Scheduled date.
+@Entity
 public class Game {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "home_team_id")
+    private Team homeTeam;
+
+    @ManyToOne
+    @JoinColumn(name = "away_team_id")
+    private Team awayTeam;
+
+    private String location;
+
+    @Column(name = "game_date")
+    private LocalDateTime gameDate;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Team getHomeTeam() {
+        return homeTeam;
+    }
+
+    public void setHomeTeam(Team homeTeam) {
+        this.homeTeam = homeTeam;
+    }
+
+    public Team getAwayTeam() {
+        return awayTeam;
+    }
+
+    public void setAwayTeam(Team awayTeam) {
+        this.awayTeam = awayTeam;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public LocalDateTime getGameDate() {
+        return gameDate;
+    }
+
+    public void setGameDate(LocalDateTime gameDate) {
+        this.gameDate = gameDate;
+    }
 }

--- a/src/main/java/com/keyin/rest/game/Game.java
+++ b/src/main/java/com/keyin/rest/game/Game.java
@@ -4,11 +4,11 @@ import jakarta.persistence.*;
 import com.keyin.rest.team.Team;
 import java.time.LocalDateTime;
 
-//A Game must have a home Team and an Away team, a String for the location, and a Scheduled date.
 @Entity
 public class Game {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @SequenceGenerator(name = "game_sequence", allocationSize = 1, initialValue = 1)
+    @GeneratedValue(generator = "game_sequence")
     private Long id;
 
     @ManyToOne
@@ -24,43 +24,24 @@ public class Game {
     @Column(name = "game_date")
     private LocalDateTime gameDate;
 
-    public Long getId() {
-        return id;
-    }
+    //Getters and Setters
+    public Long getId() {return id;}
 
-    public void setId(Long id) {
-        this.id = id;
-    }
+    public void setId(Long id) {this.id = id;}
 
-    public Team getHomeTeam() {
-        return homeTeam;
-    }
+    public Team getHomeTeam() {return homeTeam;}
 
-    public void setHomeTeam(Team homeTeam) {
-        this.homeTeam = homeTeam;
-    }
+    public void setHomeTeam(Team homeTeam) {this.homeTeam = homeTeam;}
 
-    public Team getAwayTeam() {
-        return awayTeam;
-    }
+    public Team getAwayTeam() {return awayTeam;}
 
-    public void setAwayTeam(Team awayTeam) {
-        this.awayTeam = awayTeam;
-    }
+    public void setAwayTeam(Team awayTeam) {this.awayTeam = awayTeam;}
 
-    public String getLocation() {
-        return location;
-    }
+    public String getLocation() {return location;}
 
-    public void setLocation(String location) {
-        this.location = location;
-    }
+    public void setLocation(String location) {this.location = location;}
 
-    public LocalDateTime getGameDate() {
-        return gameDate;
-    }
+    public LocalDateTime getGameDate() {return gameDate;}
 
-    public void setGameDate(LocalDateTime gameDate) {
-        this.gameDate = gameDate;
-    }
+    public void setGameDate(LocalDateTime gameDate) {this.gameDate = gameDate;}
 }

--- a/src/main/java/com/keyin/rest/game/GameController.java
+++ b/src/main/java/com/keyin/rest/game/GameController.java
@@ -87,5 +87,5 @@ public class GameController {
     }
 
     @DeleteMapping("/game/{id}")
-    public void deleteGameById(@PathVariable long id) {gameService.deleteGameByID(id);}
+    public void deleteGameById(@PathVariable long id) {gameService.deleteGameById(id);}
 }

--- a/src/main/java/com/keyin/rest/game/GameController.java
+++ b/src/main/java/com/keyin/rest/game/GameController.java
@@ -1,0 +1,4 @@
+package com.keyin.rest.game;
+
+public class GameController {
+}

--- a/src/main/java/com/keyin/rest/game/GameController.java
+++ b/src/main/java/com/keyin/rest/game/GameController.java
@@ -30,7 +30,7 @@ public class GameController {
         return ResponseEntity.ok(gameToReturn);
     }
 
-    @GetMapping("/search")
+    @GetMapping("/game_search")
     public ResponseEntity<List<Game>> searchGames(
             @RequestParam(value = "location", required = false) String location,
             @RequestParam(value = "date", required = false) String date,

--- a/src/main/java/com/keyin/rest/game/GameController.java
+++ b/src/main/java/com/keyin/rest/game/GameController.java
@@ -1,17 +1,14 @@
 package com.keyin.rest.game;
 
-import com.keyin.rest.division.Division;
-import com.keyin.rest.division.DivisionRepository;
-import com.keyin.rest.player.Player;
-import com.keyin.rest.player.PlayerService;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @CrossOrigin
@@ -31,6 +28,52 @@ public class GameController {
         }
 
         return ResponseEntity.ok(gameToReturn);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<Game>> searchGames(
+            @RequestParam(value = "location", required = false) String location,
+            @RequestParam(value = "date", required = false) String date,
+            @RequestParam(value = "homeTeamId", required = false) Long homeTeamId,
+            @RequestParam(value = "awayTeamId", required = false) Long awayTeamId,
+            @RequestParam(value = "homeTeamName", required = false) String homeTeamName,
+            @RequestParam(value = "awayTeamName", required = false) String awayTeamName) {
+
+        try {
+            // Build the map of search terms using your GameSearchCriteria enum keys
+            Map<String, Object> searchTerms = new HashMap<>();
+
+            if (location != null && !location.isEmpty()) {
+                searchTerms.put(GameSearchCriteria.LOCATION.getKey(), location);
+            }
+            if (date != null && !date.isEmpty()) {
+                searchTerms.put(GameSearchCriteria.DATE.getKey(), date);
+            }
+            if (homeTeamId != null) {
+                searchTerms.put(GameSearchCriteria.HOME_TEAM_ID.getKey(), homeTeamId);
+            }
+            if (awayTeamId != null) {
+                searchTerms.put(GameSearchCriteria.AWAY_TEAM_ID.getKey(), awayTeamId);
+            }
+            if (homeTeamName != null && !homeTeamName.isEmpty()) {
+                searchTerms.put(GameSearchCriteria.HOME_TEAM_NAME.getKey(), homeTeamName);
+            }
+            if (awayTeamName != null && !awayTeamName.isEmpty()) {
+                searchTerms.put(GameSearchCriteria.AWAY_TEAM_NAME.getKey(), awayTeamName);
+            }
+
+            if (searchTerms.isEmpty()) {
+                return ResponseEntity.ok(gameService.getAllGames());
+            }
+
+            return ResponseEntity.ok(gameService.findGamesByCriteria(searchTerms));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 
     @PostMapping("/game")

--- a/src/main/java/com/keyin/rest/game/GameController.java
+++ b/src/main/java/com/keyin/rest/game/GameController.java
@@ -1,4 +1,48 @@
 package com.keyin.rest.game;
 
+import com.keyin.rest.division.Division;
+import com.keyin.rest.division.DivisionRepository;
+import com.keyin.rest.player.Player;
+import com.keyin.rest.player.PlayerService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@CrossOrigin
 public class GameController {
+    @Autowired
+    private GameService gameService;
+
+    @GetMapping("/game")
+    public List<Game> getAllGames() {return  gameService.getAllGames();}
+
+    @GetMapping("/game/{id}")
+    public ResponseEntity<Game> getTeamById(@PathVariable long id) {
+        Game gameToReturn = gameService.getGameById(id);
+
+        if(gameToReturn == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(gameToReturn);
+    }
+
+    @PostMapping("/game")
+    public Game createGame(@RequestBody Game game) {
+        return gameService.createGame(game);
+    }
+
+    @PutMapping("/game/{id}")
+    public ResponseEntity<Game> updateGame(@PathVariable long id, @RequestBody Game game) {
+        return ResponseEntity.ok(gameService.updateGame(id, game));
+    }
+
+    @DeleteMapping("/game/{id}")
+    public void deleteGameById(@PathVariable long id) {gameService.deleteGameByID(id);}
 }

--- a/src/main/java/com/keyin/rest/game/GameRepository.java
+++ b/src/main/java/com/keyin/rest/game/GameRepository.java
@@ -1,18 +1,23 @@
 package com.keyin.rest.game;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import com.keyin.rest.team.Team;
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
 public interface GameRepository extends CrudRepository<Game, Long> {
-    List <Game>findByTeam_Home(Team homeTeam);
-    List <Game>findByTeam_Away(Team awayTeam);
-    List<Game> findByTeam_HomeId(Long homeTeamId);
-    List<Game> findByTeam_AwayId(Long awayTeamId);
-    List <Game>findByLocation(String location);
+    List<Game> findByHomeTeam_Name(String teamName);
+    List<Game> findByAwayTeam_Name(String teamName);
+    List<Game> findByHomeTeam_Id(Long id);
+    List<Game> findByAwayTeam_Id(Long id);
+    List<Game>findByLocation(String location);
     List<Game>findByGameDate(LocalDateTime gameDate);
-
+    List<Game> findByGameDateBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);
+    @Query("SELECT game FROM Game game WHERE game.homeTeam.id = :teamId OR game.awayTeam.id = :teamId")
+    List<Game> findByAnyTeamId(@Param("teamId") Long teamId);
+    @Query("SELECT game FROM Game game WHERE game.homeTeam.name = :teamName OR game.awayTeam.name = :teamName")
+    List<Game> findByAnyTeamName(@Param("teamName") String teamName);
 }

--- a/src/main/java/com/keyin/rest/game/GameRepository.java
+++ b/src/main/java/com/keyin/rest/game/GameRepository.java
@@ -1,0 +1,4 @@
+package com.keyin.rest.game;
+
+public interface GameRepository {
+}

--- a/src/main/java/com/keyin/rest/game/GameRepository.java
+++ b/src/main/java/com/keyin/rest/game/GameRepository.java
@@ -1,4 +1,18 @@
 package com.keyin.rest.game;
 
-public interface GameRepository {
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import com.keyin.rest.team.Team;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface GameRepository extends CrudRepository<Game, Long> {
+    List <Game>findByTeam_Home(Team homeTeam);
+    List <Game>findByTeam_Away(Team awayTeam);
+    List<Game> findByTeam_HomeId(Long homeTeamId);
+    List<Game> findByTeam_AwayId(Long awayTeamId);
+    List <Game>findByLocation(String location);
+    List<Game>findByGameDate(LocalDateTime gameDate);
+
 }

--- a/src/main/java/com/keyin/rest/game/GameSearchCriteria.java
+++ b/src/main/java/com/keyin/rest/game/GameSearchCriteria.java
@@ -1,0 +1,20 @@
+package com.keyin.rest.game;
+
+public enum GameSearchCriteria {
+    LOCATION("location"),
+    DATE("date"),
+    HOME_TEAM_ID("homeTeamId"),
+    AWAY_TEAM_ID("awayTeamId"),
+    HOME_TEAM_NAME("homeTeamName"),
+    AWAY_TEAM_NAME("awayTeamName");
+
+    private final String key;
+
+    GameSearchCriteria(String key) {
+        this.key = key;
+    }
+
+    public String getKey() {
+        return key;
+    }
+}

--- a/src/main/java/com/keyin/rest/game/GameService.java
+++ b/src/main/java/com/keyin/rest/game/GameService.java
@@ -1,16 +1,24 @@
 package com.keyin.rest.game;
 
 import com.keyin.rest.team.Team;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.PostMapping;
 
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import java.time.LocalDateTime;
 
 @Service
@@ -18,33 +26,19 @@ public class GameService {
     @Autowired
     private GameRepository gameRepository;
 
+    @Autowired
+    private CriteriaBuilder criteriaBuilder;
+
+    @Autowired
+    private EntityManager entityManager;
+
     public List<Game> getAllGames() {return (List<Game>) gameRepository.findAll();}
 
-    public List<Game> getGamesByTeam(Team team) {
-    List<Game> homeGames = gameRepository.findByTeam_Home(team);
-    List<Game> awayGames = gameRepository.findByTeam_Away(team);
-    return Stream.concat(homeGames.stream(), awayGames.stream()).collect(Collectors.toList());
-    }
 
     public Game getGameById(Long id) {
         Optional<Game> gameOptional = gameRepository.findById(id);
 
         return gameOptional.orElse(null);
-    }
-
-    public List<Game> getGameByLocation(String location) {
-        return gameRepository.findByLocation(location);
-    }
-
-    public List<Game> getGameByDate(LocalDateTime gameDate) {
-        return gameRepository.findByGameDate(gameDate);
-    }
-    public List<Game> getGameByTeamHome(Team homeTeam) {
-        return gameRepository.findByTeam_Home(homeTeam);
-    }
-
-    public List<Game> getGameByTeamAway(Team awayTeam) {
-        return gameRepository.findByTeam_Away(awayTeam);
     }
 
     public void deleteGameByID(long id) {gameRepository.deleteById(id);}
@@ -69,5 +63,122 @@ public class GameService {
             return gameRepository.save(gameToUpdate);
         }
         throw new EntityNotFoundException("Game not found with ID " + id);
+    }
+
+    /**
+     * Performs a dynamic search for Games based on a map of criteria.
+     * Keys in the map should correspond to the keys in GameSearchCriteria enum.
+     * Multiple criteria are combined with an AND logic.
+     *
+     * @param searchTerms A map where keys are search criteria names (from GameSearchCriteria)
+     * and values are the corresponding search values.
+     * @return A list of games matching all provided criteria.
+     * @throws IllegalArgumentException if any date/time format is invalid or a search value is not of the expected type.
+     * @throws EntityNotFoundException if a team ID is provided for a non-existent team (optional validation within criteria processing).
+     */
+    public List<Game> findGamesByCriteria(Map<String, Object> searchTerms) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Game> cq = cb.createQuery(Game.class);
+        Root<Game> game = cq.from(Game.class);
+
+        List<Predicate> predicates = new ArrayList<>();
+
+        for (Map.Entry<String, Object> entry : searchTerms.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            // Using if-else if structure to apply predicates based on criteria key
+            if (GameSearchCriteria.LOCATION.getKey().equals(key)) {
+                if (value instanceof String) {
+                    predicates.add(cb.equal(game.get("location"), (String) value));
+                } else {
+                    throw new IllegalArgumentException("Location search term must be a string.");
+                }
+            } else if (GameSearchCriteria.DATE.getKey().equals(key)) {
+                if (value instanceof String) {
+                    LocalDateTime startDateTime;
+                    LocalDateTime endDateTime;
+                    String dateInput = (String) value;
+
+                    // Flexible date parsing logic
+                    try {
+                        LocalDateTime exactDateTime = LocalDateTime.parse(dateInput);
+                        startDateTime = exactDateTime;
+                        endDateTime = exactDateTime;
+                    } catch (DateTimeParseException e1) {
+                        try {
+                            LocalDate date = LocalDate.parse(dateInput, DateTimeFormatter.ISO_LOCAL_DATE);
+                            startDateTime = date.atStartOfDay();
+                            endDateTime = date.atTime(23, 59, 59, 999_999_999);
+                        } catch (DateTimeParseException e2) {
+                            try {
+                                YearMonth yearMonth = YearMonth.parse(dateInput, DateTimeFormatter.ofPattern("yyyy-MM"));
+                                LocalDate firstDayOfMonth = yearMonth.atDay(1);
+                                LocalDate lastDayOfMonth = yearMonth.atEndOfMonth();
+                                startDateTime = firstDayOfMonth.atStartOfDay();
+                                endDateTime = lastDayOfMonth.atTime(23, 59, 59, 999_999_999);
+                            } catch (DateTimeParseException e3) {
+                                try {
+                                    Year year = Year.parse(dateInput, DateTimeFormatter.ofPattern("yyyy"));
+                                    LocalDate firstDayOfYear = year.atDay(1);
+                                    LocalDate lastDayOfYear = year.atMonth(12).atEndOfMonth();
+                                    startDateTime = firstDayOfYear.atStartOfDay();
+                                    endDateTime = lastDayOfYear.atTime(23, 59, 59, 999_999_999);
+                                } catch (DateTimeParseException e4) {
+                                    throw new IllegalArgumentException(
+                                            "Invalid date format for search criteria '" + key + "': '" + dateInput + "'. " +
+                                                    "Expected formats: 'YYYY-MM-DDTHH:MM:SS', 'YYYY-MM-DD', 'YYYY-MM', or 'YYYY'."
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    predicates.add(cb.between(game.get("gameDate"), startDateTime, endDateTime));
+                } else {
+                    throw new IllegalArgumentException("Date search term must be a string.");
+                }
+            } else if (GameSearchCriteria.HOME_TEAM_ID.getKey().equals(key)) {
+                if (value instanceof Number) {
+                    Long teamId = ((Number) value).longValue();
+                    // Optional: You could validate team existence here if you want an EntityNotFoundException
+                    // teamRepository.findById(teamId).orElseThrow(() -> new EntityNotFoundException("Home Team not found with ID: " + teamId));
+                    predicates.add(cb.equal(game.get("homeTeam").get("id"), teamId));
+                } else {
+                    throw new IllegalArgumentException("Home Team ID search term must be a number.");
+                }
+            } else if (GameSearchCriteria.AWAY_TEAM_ID.getKey().equals(key)) {
+                if (value instanceof Number) {
+                    Long teamId = ((Number) value).longValue();
+                    // Optional: Validate team existence here
+                    // teamRepository.findById(teamId).orElseThrow(() -> new new EntityNotFoundException("Away Team not found with ID: " + teamId));
+                    predicates.add(cb.equal(game.get("awayTeam").get("id"), teamId));
+                } else {
+                    throw new IllegalArgumentException("Away Team ID search term must be a number.");
+                }
+            } else if (GameSearchCriteria.HOME_TEAM_NAME.getKey().equals(key)) {
+                if (value instanceof String) {
+                    String teamName = (String) value;
+                    predicates.add(cb.equal(game.get("homeTeam").get("name"), teamName));
+                } else {
+                    throw new IllegalArgumentException("Home Team Name search term must be a string.");
+                }
+            } else if (GameSearchCriteria.AWAY_TEAM_NAME.getKey().equals(key)) {
+                if (value instanceof String) {
+                    String teamName = (String) value;
+                    predicates.add(cb.equal(game.get("awayTeam").get("name"), teamName));
+                } else {
+                    throw new IllegalArgumentException("Away Team Name search term must be a string.");
+                }
+            }
+            else {
+                throw new IllegalArgumentException("Unknown search criteria key: " + key);
+            }
+        }
+
+        // Combine all predicates with an AND operator (all conditions must be true)
+        cq.where(cb.and(predicates.toArray(new Predicate[0])));
+
+        // Execute the query and return the results
+        return entityManager.createQuery(cq).getResultList();
     }
 }

--- a/src/main/java/com/keyin/rest/game/GameService.java
+++ b/src/main/java/com/keyin/rest/game/GameService.java
@@ -1,4 +1,73 @@
 package com.keyin.rest.game;
 
+import com.keyin.rest.team.Team;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.time.LocalDateTime;
+
+@Service
 public class GameService {
+    @Autowired
+    private GameRepository gameRepository;
+
+    public List<Game> getAllGames() {return (List<Game>) gameRepository.findAll();}
+
+    public List<Game> getGamesByTeam(Team team) {
+    List<Game> homeGames = gameRepository.findByTeam_Home(team);
+    List<Game> awayGames = gameRepository.findByTeam_Away(team);
+    return Stream.concat(homeGames.stream(), awayGames.stream()).collect(Collectors.toList());
+    }
+
+    public Game getGameById(Long id) {
+        Optional<Game> gameOptional = gameRepository.findById(id);
+
+        return gameOptional.orElse(null);
+    }
+
+    public List<Game> getGameByLocation(String location) {
+        return gameRepository.findByLocation(location);
+    }
+
+    public List<Game> getGameByDate(LocalDateTime gameDate) {
+        return gameRepository.findByGameDate(gameDate);
+    }
+    public List<Game> getGameByTeamHome(Team homeTeam) {
+        return gameRepository.findByTeam_Home(homeTeam);
+    }
+
+    public List<Game> getGameByTeamAway(Team awayTeam) {
+        return gameRepository.findByTeam_Away(awayTeam);
+    }
+
+    public void deleteGameByID(long id) {gameRepository.deleteById(id);}
+
+    public Game createGame(Game newGame) { return gameRepository.save(newGame);}
+
+    public Game updateGame(long id, Game updatedGame) {
+        if (id != updatedGame.getId()) {
+            throw new DataIntegrityViolationException("Game ID mismatch");
+        }
+
+        Optional<Game> gameToUpdateOptional = gameRepository.findById(id);
+
+        if (gameToUpdateOptional.isPresent()) {
+            Game gameToUpdate = gameToUpdateOptional.get();
+
+            gameToUpdate.setAwayTeam(updatedGame.getAwayTeam());
+            gameToUpdate.setHomeTeam(updatedGame.getHomeTeam());
+            gameToUpdate.setLocation(updatedGame.getLocation());
+            gameToUpdate.setGameDate(updatedGame.getGameDate());
+
+            return gameRepository.save(gameToUpdate);
+        }
+        throw new EntityNotFoundException("Game not found with ID " + id);
+    }
 }

--- a/src/main/java/com/keyin/rest/game/GameService.java
+++ b/src/main/java/com/keyin/rest/game/GameService.java
@@ -27,9 +27,6 @@ public class GameService {
     private GameRepository gameRepository;
 
     @Autowired
-    private CriteriaBuilder criteriaBuilder;
-
-    @Autowired
     private EntityManager entityManager;
 
     public List<Game> getAllGames() {return (List<Game>) gameRepository.findAll();}
@@ -41,7 +38,7 @@ public class GameService {
         return gameOptional.orElse(null);
     }
 
-    public void deleteGameByID(long id) {gameRepository.deleteById(id);}
+    public void deleteGameById(long id) {gameRepository.deleteById(id);}
 
     public Game createGame(Game newGame) { return gameRepository.save(newGame);}
 

--- a/src/main/java/com/keyin/rest/game/GameService.java
+++ b/src/main/java/com/keyin/rest/game/GameService.java
@@ -1,0 +1,4 @@
+package com.keyin.rest.game;
+
+public class GameService {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,14 @@
+#JPA configuration
 spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+
+#MySQL Database Configuration
 #spring.datasource.url=jdbc:mysql://s4-fall-2022.ce2vcezehro2.us-east-1.rds.amazonaws.com/fall_2022
-spring.datasource.url=jdbc:mysql://localhost:3306/hockey_db_2024
+spring.datasource.url=jdbc:mysql://localhost:3306/s4_2024_hockey_reg_system_api
 spring.datasource.username=root
 spring.datasource.password=Keyin202!
+
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.jpa.show-sql=true
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration
+
+


### PR DESCRIPTION
I have tried to stay with the original code structure and naming variants. For instance, the search endpoint is /game_search where I might have named it game/search.

A key difference in this implementation is that more specific exceptions have been added at the GameService level to improve error handling.

A robust search function has been implemented at the /search endpoint. It supports flexible date matching (by year, month, or day) and allows for combining multiple search criteria. The GameSearchCriteria enum was added to make this dynamic search logic more secure and maintainable by preventing illegal or unexpected search parameters.
